### PR TITLE
过滤名称特殊字符，其他兼容问题

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -205,7 +205,8 @@ const mkTreeTocDir = (
   return items
     .filter((item) => item['parent_uuid'] === id)
     .map((item) => {
-      const fullPath = pItem.name + '/' + item.title
+      const regex = /[<>:"\/\\|?*\x00-\x1F]/g
+      const fullPath = pItem.name + '/' + item.title.replace(regex, '') // 过滤名称中的特殊字符
       item.type == 'TITLE' && F.mkdir(CONFIG.outputDir + '/' + fullPath)
       return {
         ...item,

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -27,6 +27,7 @@ export type TBookItem = {
   name: string
   user: {
     name: string
+    login: string
   }
   docs: TDocItem[]
 }

--- a/src/lib/yuque.ts
+++ b/src/lib/yuque.ts
@@ -46,14 +46,13 @@ export const loginYuque = async (accountInfo: IAccountInfo) => {
 export const getBookStacks = async () => {
   const { data } = await get<TBookStackItem[]>(YUQUE_API.yuqueBooksList)
   if (data) {
-    const list = data.reduce((prev: any, curr: { books: any }) => {
-      return prev.books.concat(curr.books)
-    }) as unknown as TBookItem[]
+    // reduce [{c:[1,2],a:'11'}] => [{c:[1,2],a:'11'}]
+    const list = data.map(item => item.books).flat() as unknown as TBookItem[]
     const _list = list.map((item: TBookItem) => {
       return {
         slug: item.slug,
         name: item.name,
-        user: item.user.name,
+        user: item.user.login,
         id: item.id,
         docs: [],
       }

--- a/src/lib/yuque.ts
+++ b/src/lib/yuque.ts
@@ -46,7 +46,7 @@ export const loginYuque = async (accountInfo: IAccountInfo) => {
 export const getBookStacks = async () => {
   const { data } = await get<TBookStackItem[]>(YUQUE_API.yuqueBooksList)
   if (data) {
-    // reduce [{c:[1,2],a:'11'}] => [{c:[1,2],a:'11'}]
+    // reduce [{c:[1,2],a:'11'}] => {c: Array(2), a: '11'}
     const list = data.map(item => item.books).flat() as unknown as TBookItem[]
     const _list = list.map((item: TBookItem) => {
       return {


### PR DESCRIPTION
- 过滤文档名称中的特殊字符，避免文档创建失败
- name为中文链接会失效，改用item.user.name
- reduce => map & flat. 只有一个元素会有问题
```javascript
[{c:[1,2],a:'11'}].reduce((prev, curr) => {
      return prev.c.concat(curr.c)
})
// {c: Array(2), a: '11'}
```